### PR TITLE
[VTD-02]: Conserta seletores de cor para texto e gradientes

### DIFF
--- a/src/components/gradientMenu.ts
+++ b/src/components/gradientMenu.ts
@@ -140,6 +140,7 @@ export class GradientMenu {
         this.handleGradientFormatChange,
       );
       this.updateGradientBar();
+      this.selectColorStop(0);
     }
   };
 
@@ -278,7 +279,9 @@ export class GradientMenu {
 
     this.activeGradientElement.colorStops.push(newStop);
     this.activeGradientElement.sortColorStops();
+    const indexOfNewColorStop = this.activeGradientElement.colorStops.indexOf(newStop);
     this.updateGradientBar();
+    this.selectColorStop(indexOfNewColorStop);
     this.eventBus.emit("edit:gradientUpdateColorStops");
     this.eventBus.emit("workarea:update");
   };

--- a/src/components/helpers/createColorControl.ts
+++ b/src/components/helpers/createColorControl.ts
@@ -29,13 +29,15 @@ export default function createColorControl(
   };
 
   const handleInputChange = () => updateValues(inputFieldEl.value);
-  const linkEvents = () =>
+  const linkEvents = () => {
     inputFieldEl.disabled = false;
     inputFieldEl.addEventListener("input", handleInputChange);
-  const unlinkEvents = () =>
+  }
+  const unlinkEvents = () => {
     inputFieldEl.disabled = true;
     inputFieldEl.value = "";
     inputFieldEl.removeEventListener("input", handleInputChange);
+  }
 
   container.append(labelEl, inputFieldEl);
 

--- a/src/components/helpers/createColorControl.ts
+++ b/src/components/helpers/createColorControl.ts
@@ -32,12 +32,12 @@ export default function createColorControl(
   const linkEvents = () => {
     inputFieldEl.disabled = false;
     inputFieldEl.addEventListener("input", handleInputChange);
-  }
+  };
   const unlinkEvents = () => {
     inputFieldEl.disabled = true;
-    inputFieldEl.value = "";
+    inputFieldEl.value = "#000000";
     inputFieldEl.removeEventListener("input", handleInputChange);
-  }
+  };
 
   container.append(labelEl, inputFieldEl);
 


### PR DESCRIPTION
- Conserta eventos de link e unlink para color control.

- Reinicia a cor padrão de um color control para preto ao deslinkar.

- Auto seleciona o primeiro color stop ao criar ou selecionar um gradiente.

Closes #28 